### PR TITLE
Add exp boost control and fix exp display

### DIFF
--- a/src/Battle.java
+++ b/src/Battle.java
@@ -128,7 +128,7 @@ public class Battle extends GameAction {
         // TODO: automatically determine whether or not to print
         if (opponent instanceof Pokemon) {
             if (getVerbose() == BattleOptions.ALL || getVerbose() == BattleOptions.EVERYTHING)
-                printBattle(p, (Pokemon) opponent);
+                printBattle(p, (Pokemon) opponent, 0);
             else if (getVerbose() == BattleOptions.SOME)
                 printShortBattle(p, (Pokemon) opponent);
 
@@ -144,7 +144,7 @@ public class Battle extends GameAction {
             int idx = 0;
             for (Pokemon opps : t) {
                 if (getVerbose() == BattleOptions.ALL || getVerbose() == BattleOptions.EVERYTHING)
-                    printBattle(p, (Pokemon) opps);
+                    printBattle(p, (Pokemon) opps, idx);
                 else if (getVerbose() == BattleOptions.SOME)
                     printShortBattle(p, (Pokemon) opps);
                 if (getVerbose() != BattleOptions.NONE) {
@@ -200,8 +200,8 @@ public class Battle extends GameAction {
     }
 
     // does not actually do the battle, just prints summary
-    public void printBattle(Pokemon us, Pokemon them) {
-        Main.appendln(DamageCalculator.summary(us, them, options));
+    public void printBattle(Pokemon us, Pokemon them, int pokemonIndex) {
+        Main.appendln(DamageCalculator.summary(us, them, options, pokemonIndex));
     }
 
     // does not actually do the battle, just prints short summary

--- a/src/DamageCalculator.java
+++ b/src/DamageCalculator.java
@@ -104,13 +104,15 @@ public class DamageCalculator {
 
     // printout of move damages between the two pokemon
     // assumes you are p1
-    public static String summary(Pokemon p1, Pokemon p2, BattleOptions options) {
+    public static String summary(Pokemon p1, Pokemon p2, BattleOptions options, int pokemonIndex) {
         StringBuilder sb = new StringBuilder();
         String endl = Constants.endl;
         StatModifier mod1 = options.getMod1();
         StatModifier mod2 = options.getMod2();
 
-        sb.append(p1.levelName() + " vs " + p2.levelName() + "          >>> EXP GIVEN: " + p2.expGiven(1) + endl);
+        int participants = options.getParticipants(pokemonIndex);
+        sb.append(p1.levelName() + " vs " + p2.levelName() + "          >>> EXP GIVEN: " + p2.expGiven(participants, p1.isBoostedExp())
+             + (participants > 1 ? String.format(" (was split in %d)", participants) : "") + (p1.isBoostedExp() ? " (TRADE)" : "") + endl);
         // sb.append(String.format("EXP to next level: %d EXP gained: %d",
         // p1.expToNextLevel(), p2.expGiven()) + endl);
         sb.append(String.format("%s (%s) ", p1.pokeName(), p1.statsStr()));

--- a/src/GameAction.java
+++ b/src/GameAction.java
@@ -39,10 +39,10 @@ public abstract class GameAction {
     };
     
     //exp boost control
-    public static final GameAction boostedExpOn = new GameAction() {
+    public static final GameAction setBoostedExp = new GameAction() {
         void performAction(Pokemon p, Inventory inv) { p.setBoostedExp(true); }
     };
-    public static final GameAction boostedExpOff = new GameAction() {
+    public static final GameAction unsetBoostedExp = new GameAction() {
         void performAction(Pokemon p, Inventory inv) { p.setBoostedExp(false); }
     };
     

--- a/src/GameAction.java
+++ b/src/GameAction.java
@@ -38,6 +38,13 @@ public abstract class GameAction {
         void performAction(Pokemon p, Inventory inv) { p.setDefBadge(true); }
     };
     
+    //exp boost control
+    public static final GameAction boostedExpOn = new GameAction() {
+        void performAction(Pokemon p, Inventory inv) { p.setBoostedExp(true); }
+    };
+    public static final GameAction boostedExpOff = new GameAction() {
+        void performAction(Pokemon p, Inventory inv) { p.setBoostedExp(false); }
+    };
     
     //not really a game action, but it's a nice hack?
     public static final GameAction printAllStats = new GameAction() {

--- a/src/Main.java
+++ b/src/Main.java
@@ -50,9 +50,7 @@ public class Main {
             p = new Pokemon(PokemonNames.getSpeciesFromName(species),level,ivs,false);
             if(ini.get("poke").containsKey("boostedExp")) {
                 boolean boostedExp = ini.get("poke", "boostedExp", boolean.class);
-                if(boostedExp) {
-                    p.setBoostedExp();
-                }
+                p.setBoostedExp(boostedExp);
             }
         } catch(NullPointerException e) {
             appendln("Error in your config file. Perhaps you have an incorrect pokemon species name?");

--- a/src/Pokemon.java
+++ b/src/Pokemon.java
@@ -66,8 +66,11 @@ public class Pokemon implements Battleable {
         setExpForLevel();
     }
 
-    public void setBoostedExp() {
-        boostedExp = true;
+    public boolean isBoostedExp() {
+        return boostedExp;
+    }
+    public void setBoostedExp(boolean boostedExp) {
+        this.boostedExp = boostedExp;
     }
 
     //TODO constructor which accepts EVs
@@ -173,9 +176,9 @@ public class Pokemon implements Battleable {
     public int getTotalExp() {
         return totalExp;
     }
-    public int expGiven(int participants) {
+    public int expGiven(int participants, boolean boostedExp) {
         return (species.getKillExp() / participants) * level / 7 * 3
-                / (isWild() ? 3 : 2);
+                / (isWild() ? 3 : 2) * 3 / (boostedExp ? 2 : 3);
     }
 
 
@@ -243,7 +246,7 @@ public class Pokemon implements Battleable {
 
     //gain num exp
     private void gainExp(int num) {
-        totalExp += num * 3 / (boostedExp ? 2 : 3);
+        totalExp += num;
         //update lvl if necessary
         while(expToNextLevel() <= 0 && level < 100) {
             level++;
@@ -273,7 +276,7 @@ public class Pokemon implements Battleable {
         //this is the one that dies like noob
         //be sure to gain EVs before the exp
         p.gainStatExp(this.getSpecies(), options.getParticipants(pokemonIndex));
-        p.gainExp(this.expGiven(options.getParticipants(pokemonIndex)));
+        p.gainExp(this.expGiven(options.getParticipants(pokemonIndex), p.isBoostedExp()));
     }
 
     @Override

--- a/src/RouteParser.java
+++ b/src/RouteParser.java
@@ -164,6 +164,12 @@ public class RouteParser {
         else if(firstToken.equalsIgnoreCase("volcanobadge")) {
             return GameAction.getVolcanoBadge;
         }
+        else if(firstToken.equalsIgnoreCase("boostedexpon")) {
+            return GameAction.boostedExpOn;
+        }
+        else if(firstToken.equalsIgnoreCase("boostedexpoff")) {
+            return GameAction.boostedExpOff;
+        }
         //inventory manipulation
         else if(firstToken.equalsIgnoreCase("get")) {
             if(n < 2) {

--- a/src/RouteParser.java
+++ b/src/RouteParser.java
@@ -164,11 +164,11 @@ public class RouteParser {
         else if(firstToken.equalsIgnoreCase("volcanobadge")) {
             return GameAction.getVolcanoBadge;
         }
-        else if(firstToken.equalsIgnoreCase("boostedexpon")) {
-            return GameAction.boostedExpOn;
+        else if(firstToken.equalsIgnoreCase("setBoostedExp")) {
+            return GameAction.setBoostedExp;
         }
-        else if(firstToken.equalsIgnoreCase("boostedexpoff")) {
-            return GameAction.boostedExpOff;
+        else if(firstToken.equalsIgnoreCase("unsetBoostedExp")) {
+            return GameAction.unsetBoostedExp;
         }
         //inventory manipulation
         else if(firstToken.equalsIgnoreCase("get")) {


### PR DESCRIPTION
The display of exp gained from an opponent has been fixed to reflect the actual exp value based on the number of participants and the status of exp boosting.

Additionally, it has been made possible to turn exp boosting on and off within the route via setBoostedExp and unsetBoostedExp as actions, just like with RouteTwo.